### PR TITLE
Add scripts/ directory, relative to text2vid.py, to os.path

### DIFF
--- a/scripts/text2vid.py
+++ b/scripts/text2vid.py
@@ -14,6 +14,10 @@ for basedir in basedirs:
         if not deforum_scripts_path_fix in sys.path:
             sys.path.extend([deforum_scripts_path_fix])
 
+current_directory = os.path.dirname(os.path.abspath(__file__))
+if current_directory not in sys.path:
+    sys.path.append(current_directory)
+
 import gradio as gr
 from modules import script_callbacks, shared
 from modules.shared import cmd_opts, opts
@@ -30,6 +34,8 @@ def process(*args):
             basedir + '/extensions/sd-webui-text2video/scripts',
             basedir + '/extensions/sd-webui-modelscope-text2video/scripts',
         ])
+    if current_directory not in sys.path:
+        sys.path.append(current_directory)
 
     run(*args)
     return f'Video ready'


### PR DESCRIPTION
Another shot at fixing #105, and a follow up to #146.

Fixes extension failing to load when installing the extension with an unusual directory name (like mine), by copying what is done in api_t2v.py.

Turns out you don't have to completely reinstall Automatic1111. You just have to rename the directory where the extension was cloned lol.

I think this accounts for the other additions to the path as well, but I didn't want to touch those in case something broke on a different setup.