### PR TITLE
save txt2vid options as txt

### DIFF
--- a/scripts/modelscope/process_modelscope.py
+++ b/scripts/modelscope/process_modelscope.py
@@ -230,7 +230,6 @@ def process_modelscope(args_dict):
           for key, value in vs.items(): 
             f.write('%s:%s\n' % (key, value))
         print(f'saving args to {args_file}')
-        
 
         # TODO: add params to the GUI
         if not video_args.skip_video_creation:

--- a/scripts/modelscope/process_modelscope.py
+++ b/scripts/modelscope/process_modelscope.py
@@ -211,9 +211,10 @@ def process_modelscope(args_dict):
 
             args.strength = 1
 
-        samples, _ = pipe.infer(args.prompt, args.n_prompt, args.steps, args.frames, args.seed + batch if args.seed != -1 else -1, args.cfg_scale,
+        samples, vs, _ = pipe.infer(args.prompt, args.n_prompt, args.steps, args.frames, args.seed + batch if args.seed != -1 else -1, args.cfg_scale,
                                 args.width, args.height, args.eta, cpu_vae, device, latents, strength=args.strength, skip_steps=skip_steps, mask=mask, is_vid2vid=args.do_vid2vid, sampler=args.sampler)
 
+        
         if batch > 0:
             outdir_current = os.path.join(get_outdir(), f"{init_timestring}_{batch}")
         print(f'text2video finished, saving frames to {outdir_current}')
@@ -223,6 +224,13 @@ def process_modelscope(args_dict):
         for i in range(len(samples)):
             cv2.imwrite(outdir_current + os.path.sep +
                         f"{i:06}.png", samples[i])
+
+        args_file = os.path.join(outdir_current,'args.txt')
+        with open(args_file, 'w') as f:
+          for key, value in vs.items(): 
+            f.write('%s:%s\n' % (key, value))
+        print(f'saving args to {args_file}')
+        
 
         # TODO: add params to the GUI
         if not video_args.skip_video_creation:

--- a/scripts/modelscope/process_modelscope.py
+++ b/scripts/modelscope/process_modelscope.py
@@ -211,7 +211,7 @@ def process_modelscope(args_dict):
 
             args.strength = 1
 
-        samples, vs, _ = pipe.infer(args.prompt, args.n_prompt, args.steps, args.frames, args.seed + batch if args.seed != -1 else -1, args.cfg_scale,
+        samples, _, infotext = pipe.infer(args.prompt, args.n_prompt, args.steps, args.frames, args.seed + batch if args.seed != -1 else -1, args.cfg_scale,
                                 args.width, args.height, args.eta, cpu_vae, device, latents, strength=args.strength, skip_steps=skip_steps, mask=mask, is_vid2vid=args.do_vid2vid, sampler=args.sampler)
 
         
@@ -225,11 +225,13 @@ def process_modelscope(args_dict):
             cv2.imwrite(outdir_current + os.path.sep +
                         f"{i:06}.png", samples[i])
 
-        args_file = os.path.join(outdir_current,'args.txt')
-        with open(args_file, 'w') as f:
-          for key, value in vs.items(): 
-            f.write('%s:%s\n' % (key, value))
-        print(f'saving args to {args_file}')
+        # save settings to a file
+        if opts.data.get("modelscope_save_info_to_file") if opts.data is not None and opts.data.get("modelscope_save_info_to_file") is not None else False:
+
+            args_file = os.path.join(outdir_current,'args.txt')
+            with open(args_file, 'w', encoding='utf-8') as f:
+                print(f'saving args to {args_file}')
+                f.write(infotext)
 
         # TODO: add params to the GUI
         if not video_args.skip_video_creation:

--- a/scripts/modelscope/t2v_pipeline.py
+++ b/scripts/modelscope/t2v_pipeline.py
@@ -362,7 +362,7 @@ class TextToVideoSynthesis():
                     vd_out, '(b f) c h w -> b c f h w', b=bs_vd)
         vd_out = vd_out.type(torch.float32).cpu()
 
-        video_path= self.postprocess_video(vd_out)
+        video_path = self.postprocess_video(vd_out)
         if self.keep_in_vram == "None":
             self.sd_model.to("cpu")
         if self.keep_in_vram != "All":

--- a/scripts/modelscope/t2v_pipeline.py
+++ b/scripts/modelscope/t2v_pipeline.py
@@ -382,7 +382,7 @@ class TextToVideoSynthesis():
         del video_data
         torch_gc()
         last_tensor = self.last_tensor
-        return video_path, last_tensor, self.create_infotext(vars)
+        return video_path, last_tensor, create_infotext(vars)
 
     def cleanup(self):
         pass

--- a/scripts/modelscope/t2v_pipeline.py
+++ b/scripts/modelscope/t2v_pipeline.py
@@ -21,6 +21,7 @@ import cv2
 from modelscope.t2v_model import UNetSD, AutoencoderKL, GaussianDiffusion, beta_schedule
 from modules import devices, shared
 from modules import prompt_parser
+from modules import generation_parameters_copypaste
 from samplers.uni_pc.sampler import UniPCSampler
 from samplers.samplers_common import Txt2VideoSampler
 from samplers.samplers_common import available_samplers
@@ -191,6 +192,15 @@ class TextToVideoSynthesis():
 
         out = latents.type(torch.float32).cpu()
         return out
+
+    def create_infotext(vars:dict):
+        prompt = vars.pop('prompt')
+        n_prompt = vars.pop('n_prompt') if 'n_prompt' in vars else ""
+        generation_params_text = ", ".join([k if k == v else f'{k}: {generation_parameters_copypaste.quote(v)}' for k, v in vars.items() if v is not None])
+
+        negative_prompt_text = "\nNegative prompt: " + n_prompt if len(n_prompt) > 0 else ""
+
+        return f"{prompt}{negative_prompt_text}\n{generation_params_text}".strip()
 
     # @torch.compile()
     def infer(
@@ -381,7 +391,7 @@ class TextToVideoSynthesis():
         del video_data
         torch_gc()
         last_tensor = self.last_tensor
-        return video_path, vars, last_tensor
+        return video_path, last_tensor, create_infotext(vars)
 
     def cleanup(self):
         pass

--- a/scripts/modelscope/t2v_pipeline.py
+++ b/scripts/modelscope/t2v_pipeline.py
@@ -391,7 +391,7 @@ class TextToVideoSynthesis():
         del video_data
         torch_gc()
         last_tensor = self.last_tensor
-        return video_path, last_tensor, create_infotext(vars)
+        return video_path, last_tensor, self.create_infotext(vars)
 
     def cleanup(self):
         pass

--- a/scripts/modelscope/t2v_pipeline.py
+++ b/scripts/modelscope/t2v_pipeline.py
@@ -362,7 +362,7 @@ class TextToVideoSynthesis():
                     vd_out, '(b f) c h w -> b c f h w', b=bs_vd)
         vd_out = vd_out.type(torch.float32).cpu()
 
-        video_path = self.postprocess_video(vd_out)
+        video_path= self.postprocess_video(vd_out)
         if self.keep_in_vram == "None":
             self.sd_model.to("cpu")
         if self.keep_in_vram != "All":
@@ -381,7 +381,7 @@ class TextToVideoSynthesis():
         del video_data
         torch_gc()
         last_tensor = self.last_tensor
-        return video_path, last_tensor
+        return video_path, vars, last_tensor
 
     def cleanup(self):
         pass

--- a/scripts/t2v_helpers/args.py
+++ b/scripts/t2v_helpers/args.py
@@ -13,7 +13,7 @@ from modules.shared import opts
 welcome_text_videocrafter = '''- Download pretrained T2V models via <a style="color:SteelBlue" href="https://drive.google.com/file/d/13ZZTXyAKM3x0tObRQOQWdtnrI2ARWYf_/view?usp=share_link">this link</a>, and put the model.ckpt in models/VideoCrafter/model.ckpt. Then use the same GUI pipeline as ModelScope does.
 '''
 
-welcome_text_modelscope = '''- Put your models to stable-diffusion-webui/models/text2video. Make sure you have a text file named 'configuration.json' in the downloaded models folders (click on the ⬇️ character to the right, don't save via right-click). Recommended requirements start at 6 GBs of VRAM.
+welcome_text_modelscope = '''- Put your models to stable-diffusion-webui/models/text2video, each full model should have its own folder. A model consists of four parts: `VQGAN_autoencoder.pth`, `configuration.json`, `open_clip_pytorch_model.bin` and `text2video_pytorch_model.pth`. Make sure `configuration.json` is a text JSON file and not a saved HTML webpage (click on the ⬇️ character to the right, don't save via right-click). Recommended requirements start at 6 GBs of VRAM.
 
 <a style="color:SteelBlue" href="https://github.com/kabachuha/sd-webui-text2video#prominent-fine-tunes">A list of prominent fine-tunes</a> is a good starting point for models search.
 

--- a/scripts/text2vid.py
+++ b/scripts/text2vid.py
@@ -107,6 +107,8 @@ def on_ui_settings():
         "GPU (half precision)", "VAE Mode:", gr.Radio, {"interactive": True, "choices": ['GPU (half precision)', 'GPU', 'CPU (Low VRAM)']}, section=section))
     shared.opts.add_option("modelscope_deforum_show_n_videos", shared.OptionInfo(
         -1, "How many videos to show on the right panel on completion (-1 = show all)", gr.Number, {"interactive": True, "visible": True}, section=section))
+    shared.opts.add_option("modelscope_save_info_to_file", shared.OptionInfo(
+        False, "Save generation params to a text file near the video", gr.Checkbox, {'interactive':True, 'visible':True}, section=section))
 
 script_callbacks.on_ui_tabs(on_ui_tabs)
 script_callbacks.on_ui_settings(on_ui_settings)


### PR DESCRIPTION
I’ve seen a number of users request saving each video output’s arguments for reuse (especially seed values, which help in the vid2vid step). These updates will create an `args.txt` file in each output folder so users can batch output videos and still retain necessary arguments for later use.