### PR TITLE
Fix Stable LoRA Text Encoder Loading

### DIFF
--- a/scripts/stable_lora/scripts/lora_webui.py
+++ b/scripts/stable_lora/scripts/lora_webui.py
@@ -184,7 +184,7 @@ class StableLoraScript(Text2VideoExtension, StableLoraProcessor):
 
             if len(lora_files) == 0: return
 
-            for i, model in enumerate([p.sd_model, p.clip_encoder]):
+            for i, model in enumerate([p.sd_model, p.clip_encoder.model.transformer]):
                 lora_alpha = (lora_alpha * use_multiplier) / len(lora_files)
 
                 lora_files_list = self.load_loras_from_list(lora_files)


### PR DESCRIPTION
Seems the trainer outputs in a different format that excludes `model.transformer`. This should fix the issue.